### PR TITLE
update ds.cbind/cbindDS pair

### DIFF
--- a/R/cbindDS.R
+++ b/R/cbindDS.R
@@ -1,82 +1,58 @@
-#' @title cbindDS called by ds.cbind c
+#' @title cbindDS called by ds.cbind
 #' @description serverside assign function that takes a
 #' sequence of vector, matrix or data-frame arguments
-#' and combines them by column to produce a matrix.
+#' and combines them by column to produce a data-frame.
 #' @details A sequence of vector, matrix or data-frame arguments
-#' is combined column by column to produce a matrix
-#' which is written to the serverside. For more details see
-#' help for {ds.cbind} and the native R function {cbind}.
+#' is combined column by column to produce a data-frame
+#' which is written to the serverside. A critical requirement is that
+#' the length of all component variables, and the number of rows of the
+#' component data.frames or matrices must all be the same. The output
+#' data.frame will then have this same number of rows. For more details 
+#' see help for \code{ds.cbind} and the native R function \code{cbind}.
 #' @param x.names.transmit This is a vector of character strings
-#' representing the names of the elemental
-#' components to be combined converted into a transmittable
-#' format. This argument is fully specified by the <x> argument
-#' of {ds.cbind}
-#' @param colnames.transmit This is NULL or a vector of character
-#' strings representing forced column names for the output object
-#' converted into a transmittable format. This argument is fully
-#' specified by the <force.colnames> argument
-#' of {ds.cbind}.
-#' @return the object specified by the <newobj> argument
-#' of {ds.cbind}(or default name <cbind.out>)
-#' which is written to the serverside. Just like the {cbind} function in
-#' native R, the output object is of class matrix unless one or more
-#' of the input objects is a data.frame in which case the class of the
-#' output object is data.frame. As well as writing the output object as <newobj>
-#' on the serverside, two validity messages are returned
-#' indicating whether <newobj> has been created in each data source and if so whether
-#' it is in a valid form. If its form is not valid in at least one study - e.g. because
-#' a disclosure trap was tripped and creation of the full output object was blocked -
-#' ds.cbind() also returns any studysideMessages that can explain the error in creating
-#' the full output object. As well as appearing on the screen at run time,if you wish to
-#' see the relevant studysideMessages at a later date you can use the {ds.message}
-#' function. If you type ds.message("<newobj>") it will print out the relevant
-#' studysideMessage from any datasource in which there was an error in creating <newobj>
-#' and a studysideMessage was saved. If there was no error and <newobj> was created
-#' without problems no studysideMessage will have been saved and ds.message("<newobj>")
-#' will return the message: "ALL OK: there are no studysideMessage(s) on this datasource".
-#' @author Paul Burton for DataSHIELD Development Team
+#' representing the names of the elemental components to be combined
+#' converted into a transmittable format. This argument is fully specified
+#' by the \code{x} argument of the client-side \code{ds.cbind} function.
+#' @param colnames.transmit This is a vector of character strings representing
+#' column names for the output object converted into a transmittable format. 
+#' @return the object specified by the \code{newobj} argument
+#' of \code{ds.cbind} (or default name \code{cbind.newobj})
+#' which is written to the serverside. The output object is of class data.frame.
+#' @author Paul Burton and Demetris Avraam for DataSHIELD Development Team
 #' @export
-cbindDS <- function(x.names.transmit=NULL,colnames.transmit=NULL){
-#########################################################################
-# DataSHIELD MODULE: CAPTURE THE nfilter SETTINGS           			#
-#thr<-listDisclosureSettingsDS()							#
-#nfilter.tab<-as.numeric(thr$nfilter.tab)								#
-#nfilter.glm<-as.numeric(thr$nfilter.glm)								#
-#nfilter.subset<-as.numeric(thr$nfilter.subset)          				#
-#nfilter.string<-as.numeric(thr$nfilter.string)              			#
-#nfilter.stringShort<-as.numeric(thr$nfilter.stringShort)    			#
-#nfilter.kNN<-as.numeric(thr$nfilter.kNN)								#
-#datashield.privacyLevel<-as.numeric(thr$datashield.privacyLevel)        #
-#########################################################################
+#' 
+cbindDS <- function(x.names.transmit=NULL, colnames.transmit=NULL){
+  
+  x.names.input <- x.names.transmit
+  x.names.act1 <- unlist(strsplit(x.names.input, split=","))
+  x.names.act2 <- paste(x.names.act1, collapse=",")
+  
+  eval.code.x.names <- paste0("cbind(", x.names.act2, ")")
+  
+  output.cbind <- eval(parse(text=eval.code.x.names), envir = parent.frame())
+  # convert the object from a 'matrix' to a 'data.frame'
+  output.cbind <- as.data.frame(output.cbind)
+  
+  colnames.input <- colnames.transmit
+  colnames.act1 <- unlist(strsplit(colnames.input, split=","))
+  
+  # Detects which column names (if any) have the '$' in their string and detach 
+  # the '$' sign and any characters before that 
+  detect.idx <- grep('[$]', colnames.act1)
+  if(length(detect.idx) > 0){
+    detach.names <- strsplit(colnames.act1[detect.idx], "\\$", perl=TRUE)[[1]][2]
+    colnames.act1[detect.idx] <- detach.names
+  }
+  
+  # Check if any column names are duplicated and add a suffix ".k" to the kth replicate
+  colnames.act1 <- make.names(colnames.act1, unique=TRUE)
+  
+  colnames(output.cbind) <- colnames.act1
+  
+  output.obj <- output.cbind
+  
+  return(output.obj)
 
-x.names.input<-x.names.transmit
-x.names.act1<-unlist(strsplit(x.names.input, split=","))
-x.names.act2<-paste(x.names.act1,collapse=",")
-
-eval.code.x.names<-paste0("cbind(",x.names.act2,")")
-
-output.cbind<-eval(parse(text=eval.code.x.names), envir = parent.frame())
-
-colnames.input<-colnames.transmit
-colnames.act1<-unlist(strsplit(colnames.input, split=","))
-
-#Check length of colnames vector
-required.length.colnames.vector<-ncol(output.cbind)
-generated.length.colnames.vector<-length(colnames.act1)
-
-
-if(required.length.colnames.vector!=generated.length.colnames.vector){
-rescue.names.vector<-paste0("V",as.character(1:required.length.colnames.vector))
-studysideMessage<-paste0("Number of column names does not match number of columns in output object. Here ", required.length.colnames.vector, " names are required. Please see help for {ds.cbind} function")
-return(list(studysideMessage=studysideMessage))
 }
-
-colnames(output.cbind)<-colnames.act1
-
-output.obj<-output.cbind
-
-return(output.obj)
-}
-
 # ASSIGN FUNCTION
 # cbindDS

--- a/man/cbindDS.Rd
+++ b/man/cbindDS.Rd
@@ -2,54 +2,38 @@
 % Please edit documentation in R/cbindDS.R
 \name{cbindDS}
 \alias{cbindDS}
-\title{cbindDS called by ds.cbind c}
+\title{cbindDS called by ds.cbind}
 \usage{
 cbindDS(x.names.transmit = NULL, colnames.transmit = NULL)
 }
 \arguments{
 \item{x.names.transmit}{This is a vector of character strings
-representing the names of the elemental
-components to be combined converted into a transmittable
-format. This argument is fully specified by the <x> argument
-of {ds.cbind}}
+representing the names of the elemental components to be combined
+converted into a transmittable format. This argument is fully specified
+by the \code{x} argument of the client-side \code{ds.cbind} function.}
 
-\item{colnames.transmit}{This is NULL or a vector of character
-strings representing forced column names for the output object
-converted into a transmittable format. This argument is fully
-specified by the <force.colnames> argument
-of {ds.cbind}.}
+\item{colnames.transmit}{This is a vector of character strings representing
+column names for the output object converted into a transmittable format.}
 }
 \value{
-the object specified by the <newobj> argument
-of {ds.cbind}(or default name <cbind.out>)
-which is written to the serverside. Just like the {cbind} function in
-native R, the output object is of class matrix unless one or more
-of the input objects is a data.frame in which case the class of the
-output object is data.frame. As well as writing the output object as <newobj>
-on the serverside, two validity messages are returned
-indicating whether <newobj> has been created in each data source and if so whether
-it is in a valid form. If its form is not valid in at least one study - e.g. because
-a disclosure trap was tripped and creation of the full output object was blocked -
-ds.cbind() also returns any studysideMessages that can explain the error in creating
-the full output object. As well as appearing on the screen at run time,if you wish to
-see the relevant studysideMessages at a later date you can use the {ds.message}
-function. If you type ds.message("<newobj>") it will print out the relevant
-studysideMessage from any datasource in which there was an error in creating <newobj>
-and a studysideMessage was saved. If there was no error and <newobj> was created
-without problems no studysideMessage will have been saved and ds.message("<newobj>")
-will return the message: "ALL OK: there are no studysideMessage(s) on this datasource".
+the object specified by the \code{newobj} argument
+of \code{ds.cbind} (or default name \code{cbind.newobj})
+which is written to the serverside. The output object is of class data.frame.
 }
 \description{
 serverside assign function that takes a
 sequence of vector, matrix or data-frame arguments
-and combines them by column to produce a matrix.
+and combines them by column to produce a data-frame.
 }
 \details{
 A sequence of vector, matrix or data-frame arguments
-is combined column by column to produce a matrix
-which is written to the serverside. For more details see
-help for {ds.cbind} and the native R function {cbind}.
+is combined column by column to produce a data-frame
+which is written to the serverside. A critical requirement is that
+the length of all component variables, and the number of rows of the
+component data.frames or matrices must all be the same. The output
+data.frame will then have this same number of rows. For more details 
+see help for \code{ds.cbind} and the native R function \code{cbind}.
 }
 \author{
-Paul Burton for DataSHIELD Development Team
+Paul Burton and Demetris Avraam for DataSHIELD Development Team
 }


### PR DESCRIPTION
The function now 1) removes any $ signs if any from the column names, 2) specifies the column names in the correct order as the corresponding order of the variables in each study, 3) generates a dataframe instead of a matrix, 4) has additional checks to check it the number of rows are the same in all the components to cbind and if any column names are duplicated. Also additional examples were added in the headers