### PR TITLE
fixes for *merSLMA*

### DIFF
--- a/R/glmerSLMADS.assign.R
+++ b/R/glmerSLMADS.assign.R
@@ -1,5 +1,5 @@
 #' @title Fitting generalized linear mixed effect models - serverside function
-#' @description glmerSLMADS.assing is the same as glmerSLMADS2 which fits a generalized linear
+#' @description glmerSLMADS.assign is the same as glmerSLMADS2 which fits a generalized linear
 #' mixed effects model (glme) per study and saves the outcomes in each study
 #' @details glmerSLMADS.assign is a serverside function called by ds.glmerSLMA on the clientside.
 #' The analytic work engine is the glmer function in R which sits in the lme4 package.
@@ -154,24 +154,11 @@ glmerSLMADS.assign <- function(formula, offset, weights, dataName, family,
   
   #### BEFORE going further we use the glm1 checks
   
-  formulatext.glm = originalFormula
+  # This command creates a formula object without the grouping factors for running the standard glm checks
   
-  # Convert formula string into formula string that will work for GLM
-  formulatext.glm <- gsub(" ", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(1", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(0", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub(")", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("|", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub(":", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("/", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("++", "+", formulatext.glm, fixed=TRUE)
-  formula.glm <- stats::as.formula(formulatext.glm)
+  formula2use.glm <- lme4::nobars(formula2use)
   
-  formula2use.glm <- stats::as.formula(paste0(Reduce(paste, deparse(formula.glm ))), env = parent.frame()) # here we need the formula as a 'call' object
-  
-  # mod.glm.ds <- stats::glm(formula2use.glm, family="gaussian", x=TRUE, control=stats::glm.control(maxit=1), contrasts=NULL, data=dataDF)
-  mod.glm.ds <- stats::glm(formula2use.glm, family=family, x=TRUE, offset=offset, weights=weights, data=dataDF)
+  mod.glm.ds <- stats::glm(formula2use.glm, family="gaussian", x=TRUE, offset=offset, weights=weights, data=dataDF)
 
   y.vect<-mod.glm.ds$y
   X.mat<-mod.glm.ds$x

--- a/R/glmerSLMADS2.R
+++ b/R/glmerSLMADS2.R
@@ -161,24 +161,11 @@ glmerSLMADS2 <- function(formula, offset, weights, dataName, family,
   
   #### BEFORE going further we use the glm1 checks
   
-  formulatext.glm = originalFormula
+  # This command creates a formula object without the grouping factors for running the standard glm checks
   
-  # Convert formula string into formula string that will work for GLM
-  formulatext.glm <- gsub(" ", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(1", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(0", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub(")", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("|", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub(":", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("/", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("++", "+", formulatext.glm, fixed=TRUE)
-  formula.glm <- stats::as.formula(formulatext.glm)
+  formula2use.glm <- lme4::nobars(formula2use)
   
-  formula2use.glm <- stats::as.formula(paste0(Reduce(paste, deparse(formula.glm ))), env = parent.frame()) # here we need the formula as a 'call' object
-  
-  # mod.glm.ds <- stats::glm(formula2use.glm, family="gaussian", x=TRUE, control=stats::glm.control(maxit=1), contrasts=NULL, data=dataDF)
-  mod.glm.ds <- stats::glm(formula2use.glm, family=family, x=TRUE, offset=offset, weights=weights, data=dataDF)
+  mod.glm.ds <- stats::glm(formula2use.glm, family="gaussian", x=TRUE, offset=offset, weights=weights, data=dataDF)
 
   y.vect<-mod.glm.ds$y
   X.mat<-mod.glm.ds$x

--- a/R/lmerSLMADS.assign.R
+++ b/R/lmerSLMADS.assign.R
@@ -161,21 +161,9 @@ lmerSLMADS.assign <- function(formula, offset, weights, dataName, REML = TRUE,
   
   #### BEFORE going further we use the glm1 checks
 
-  formulatext.glm = formula
-
-  # Convert formula string into formula string that will work for GLM
-  formulatext.glm <- gsub(" ", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(1", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(0", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub(")", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("|", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub(":", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("/", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("++", "+", formulatext.glm, fixed=TRUE)
-  formula.glm <- stats::as.formula(formulatext.glm)
+  # This command creates a formula object without the grouping factors for running the standard glm checks
   
-  formula2use.glm <- stats::as.formula(paste0(Reduce(paste, deparse(formula.glm ))), env = parent.frame()) # here we need the formula as a 'call' object
+  formula2use.glm <- lme4::nobars(formula2use)
   
   mod.glm.ds <- stats::glm(formula2use.glm, family="gaussian", x=TRUE, offset=offset.to.use, weights=weights.to.use, data=dataDF)
 

--- a/R/lmerSLMADS2.R
+++ b/R/lmerSLMADS2.R
@@ -170,21 +170,9 @@ lmerSLMADS2 <- function(formula, offset, weights, dataName, REML = TRUE,
   
   #### BEFORE going further we use the glm1 checks
 
-  formulatext.glm = formula
-
-  # Convert formula string into formula string that will work for GLM
-  formulatext.glm <- gsub(" ", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(1", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("(0", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub(")", "", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("|", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub(":", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("/", "+", formulatext.glm, fixed=TRUE)
-  formulatext.glm <- gsub("++", "+", formulatext.glm, fixed=TRUE)
-  formula.glm <- stats::as.formula(formulatext.glm)
+  # This command creates a formula object without the grouping factors for running the standard glm checks
   
-  formula2use.glm <- stats::as.formula(paste0(Reduce(paste, deparse(formula.glm ))), env = parent.frame()) # here we need the formula as a 'call' object
+  formula2use.glm <- lme4::nobars(formula2use)
   
   mod.glm.ds <- stats::glm(formula2use.glm, family="gaussian", x=TRUE, offset=offset.to.use, weights=weights.to.use, data=dataDF)
 

--- a/man/glmerSLMADS.assign.Rd
+++ b/man/glmerSLMADS.assign.Rd
@@ -55,7 +55,7 @@ writes glmerMod object summarising the fitted model to the serverside.
 For more detailed information see help for ds.glmerSLMA.
 }
 \description{
-glmerSLMADS.assing is the same as glmerSLMADS2 which fits a generalized linear
+glmerSLMADS.assign is the same as glmerSLMADS2 which fits a generalized linear
 mixed effects model (glme) per study and saves the outcomes in each study
 }
 \details{


### PR DESCRIPTION
 1. Fixed name error with glmerSLMADS.assign

2. In the *merSLMA* functions removed mixed model grouping terms from disclosure checks that use the glm code. This was causing disclosure errors when using small groups e.g. mothers and children