### PR TITLE
V6.2 dev mg

### DIFF
--- a/R/glmerSLMADS2.R
+++ b/R/glmerSLMADS2.R
@@ -374,18 +374,29 @@ if(control_type=="check.conv.grad")
       }
     }
     
-    #mg <- lme4::lmer(formula2use, offset=offset, weights=weights, data=dataDF, REML = REML, verbose = verbose, control = control.obj)
     
-	  iterations <- utils::capture.output(try(mg <- lme4::glmer(formula2use, offset=offset, weights=weights, data=dataDF,
-	                                       family = family, nAGQ=nAGQ,verbose = verbose, control=control.obj, start = start)))
+	  #iterations <- utils::capture.output(try(mg <- lme4::glmer(formula2use, offset=offset, weights=weights, data=dataDF,
+	 #                                      family = family, nAGQ=nAGQ,verbose = verbose, control=control.obj, start = start)))
+	  
+	  iterations = utils::capture.output(mg <- try(lme4::glmer(formula2use, offset=offset, weights=weights, data=dataDF,
+	                                                           family = family, nAGQ=nAGQ,verbose = verbose, control=control.obj, start = start)))
+	  
+	  if(inherits(mg, "try-error")) {          # error happened
+	    summary_mg = list()
+	    summary_mg$errorMessage = conditionMessage(attr(mg, "condition"))  # the error message
+	    summary_mg$disclosure.risk = 1
+	  } else
+	  {
+	    summary_mg = summary(mg)
+	    summary_mg$residuals <- NULL
+	    summary_mg$errorMessage <- errorMessage
+	    summary_mg$disclosure.risk <- disclosure.risk
+	    summary_mg$iterations <- iterations
+	    summary_mg$control.info <- control.obj
+	    summary_mg$nAGQ.info <- nAGQ
+	  }
 
-    summary_mg <- summary(mg)
-    summary_mg$residuals <- NULL
-    summary_mg$errorMessage <- errorMessage
-    summary_mg$disclosure.risk <- disclosure.risk
-    summary_mg$iterations <- iterations
- 	  summary_mg$control.info <- control.obj
-	  summary_mg$nAGQ.info <- nAGQ
+
     outlist <- summary_mg
     
     outlist$Ntotal <- Ntotal

--- a/R/lmerSLMADS2.R
+++ b/R/lmerSLMADS2.R
@@ -367,14 +367,24 @@ if(!is.null(optimizer)&&optimizer!="nloptwrap")
 
 
     #mg <- lme4::lmer(formula2use, offset=offset, weights=weights, data=dataDF, REML = REML, verbose = verbose, control = control.obj)
-    iterations <- utils::capture.output(try(mg <- lme4::lmer(formula2use, offset=offset.to.use, weights=weights.to.use, data=dataDF, REML = REML, verbose = verbose, control = control.obj)))
+    #iterations <- utils::capture.output(try(mg <- lme4::lmer(formula2use, offset=offset.to.use, weights=weights.to.use, data=dataDF, REML = REML, verbose = verbose, control = control.obj)))
     
-    summary_mg = summary(mg)
-    summary_mg$residuals <- NULL
-    summary_mg$errorMessage = errorMessage
-    summary_mg$disclosure.risk = disclosure.risk
-    summary_mg$iterations = iterations
-	  summary_mg$control.info = control.obj
+    iterations = utils::capture.output(mg <- try(lme4::lmer(formula2use, offset=offset.to.use, weights=weights.to.use, data=dataDF, REML = REML, verbose = verbose, control = control.obj)))
+
+    if(inherits(mg, "try-error")) {          # error happened
+      summary_mg = list()
+      summary_mg$errorMessage = conditionMessage(attr(mg, "condition"))  # the error message
+      summary_mg$disclosure.risk = 1
+    } else
+    {
+      summary_mg = summary(mg)
+      summary_mg$residuals <- NULL
+      summary_mg$errorMessage = errorMessage
+      summary_mg$disclosure.risk = disclosure.risk
+      summary_mg$iterations = iterations
+      summary_mg$control.info = control.obj
+    }
+
     outlist = summary_mg
     
     outlist$Ntotal <- Ntotal


### PR DESCRIPTION
The purpose of this change is to stop users seeing a message `"the object mg does not exist"`. This could happen when the `lmer` or `glmer` function failed to generate the mg object but code execution continued. It then failed when mg was referenced.

Note that this change alters the response of the function for some of the tests in `dsBaseClient`. I have made a separate request that updates those tests to deal with the new responses.