### PR TITLE
Changes to submit to CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,10 @@ Package: dsBase
 Title: DataSHIELD Server Site Base Functions
 Description: DataSHIELD Server Site Base Functions.
 Version: 6.3.1
-Author: DataSHIELD Developers <datashield@liverpool.ac.uk>
-Maintainer: DataSHIELD Developers <datashield@liverpool.ac.uk>
+Authors@R: person(given = "DataSHIELD",
+                    family = "Developers",
+                    role = c("aut", "cre"),
+                    email = "datashield@liverpool.ac.uk")
 License: GPL-3
 Depends: 
     R (>= 4.0.0)

--- a/R/boxPlotGGDS.R
+++ b/R/boxPlotGGDS.R
@@ -15,9 +15,7 @@
 #' @param group \code{character} (default \code{NULL}) Name of the first grouping variable. 
 #' @param group2 \code{character} (default \code{NULL}) Name of the second grouping variable. 
 #'
-#' @return  \cr
-#' 
-#' \code{list} with: \cr
+#' @return \code{list} with: \cr
 #' -\code{data frame} Geometrical parameters (identity stats of ggplot) \cr
 #' -\code{character} Type of plot (single_group, double_group or no_group) \cr
 #' 

--- a/man/boxPlotGGDS.Rd
+++ b/man/boxPlotGGDS.Rd
@@ -19,8 +19,6 @@ boxPlotGGDS(data_table, group = NULL, group2 = NULL)
 \item{group2}{\code{character} (default \code{NULL}) Name of the second grouping variable.}
 }
 \value{
-\cr
-
 \code{list} with: \cr
 -\code{data frame} Geometrical parameters (identity stats of ggplot) \cr
 -\code{character} Type of plot (single_group, double_group or no_group) \cr


### PR DESCRIPTION
1. The file `R/boxPlotGGDS.R` had an additional `\cr` immediately after the `@return` tag, which resulted in the following error message when running `devtools::build_manual()`:

    ```bash
    Error in `(function (command = NULL, args = character(), error_on_status = TRUE, …`:
    ! System command 'R' failed
    ---
    Exit status: 1
    Stdout & stderr (last 10 lines, see `$stderr` for more):
    
    Underfull \hbox (badness 10000) in paragraph at lines 858--862
    
    
    [18]
    
    ! LaTeX Error: There's no line here to end.
    
    See the LaTeX manual or LaTeX Companion for expl
    Error in running tools::texi2pdf()
    ---
    Type .Last.error to see the more details.
    ```
    
    This issue was addressed by removing this _superfluous_ line.

2. The `DESCRIPTION` file was updated to replace the `Author` and `Maintainer` by the `Authors@R` tag, as this is the expected by CRAN checks.