### PR TITLE
V6.3.3 dev test skipping tests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,4 +48,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
-          build_args: 'c("--no-manual", ,"--compact-vignettes=gs+qpdf")'
+          build_args: 'c("--no-manual", "--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,4 +48,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
-          build_args: 'c("--no-manual", "--as-cran", "--compact-vignettes=gs+qpdf")'
+          build_args: 'c("--no-manual", ,"--compact-vignettes=gs+qpdf")'

--- a/tests/testthat/test-perf-meanDS.R
+++ b/tests/testthat/test-perf-meanDS.R
@@ -12,6 +12,10 @@
 # Set up
 #
 
+# avoid performance tests on CRAN and GitHub Actions
+testthat::skip_on_cran()
+testthat::skip_on_ci()
+
 context("meanDS::perf::setup")
 
 set.standard.disclosure.settings()

--- a/tests/testthat/test-perf-varDS.R
+++ b/tests/testthat/test-perf-varDS.R
@@ -12,6 +12,10 @@
 # Set up
 #
 
+# avoid performance tests on CRAN and GitHub Actions
+testthat::skip_on_cran()
+testthat::skip_on_ci()
+
 context("varDS::perf::setup")
 
 set.standard.disclosure.settings()


### PR DESCRIPTION
Please ignore until further notice. This is intended to test if the performance tests can be ignored when running checks with GitHub Actions and potentially on CRAN.