### PR TITLE
fix: return family name in glmDS2 result

### DIFF
--- a/R/glmDS2.R
+++ b/R/glmDS2.R
@@ -382,7 +382,7 @@ glmDS2 <- function (formula, family, beta.vect, offset, weights, dataName) {
     errorMessage.combined <- "No errors"
   }
   
-  return(list(family=f, info.matrix=info.matrix, score.vect=score.vect, numsubs=numsubs, dev=dev,
+  return(list(family=f$family, info.matrix=info.matrix, score.vect=score.vect, numsubs=numsubs, dev=dev,
               Nvalid=Nvalid,Nmissing=Nmissing,Ntotal=Ntotal,disclosure.risk=disclosure.risk,
               errorMessage2=errorMessage.combined))  
  


### PR DESCRIPTION
Fix for #465, glmDS2 only.

The returned value in JSON is now

```json
{
  "server1": {
    "family": "binomial",
    "info.matrix": [
      [
        433,
        216.5,
        11854.745,
        680.874629249998
      ],
      [
        216.5,
        216.5,
        5813.9525,
        351.703075
      ],
      [
        11854.745,
        5813.9525,
        334837.6683,
        18532.8212879925
      ],
      [
        680.874629249998,
        351.703075,
        18532.8212879925,
        1144.17968050697
      ]
    ],
    "score.vect": [
      [
        -842
      ],
      [
        -424
      ],
      [
        -22985.76
      ],
      [
        -1327.9215585
      ]
    ],
    "numsubs": 1732,
    "dev": 2401.06183345965,
    "Nvalid": 1732,
    "Nmissing": 431,
    "Ntotal": 2163,
    "disclosure.risk": 0,
    "errorMessage2": "No errors"
  }
}
```