### PR TITLE
Add array and matrix to lengthDS permitted classes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,7 +76,7 @@ Imports:
 Suggests:
     spelling,
     testthat (>= 3.0.0)
-RoxygenNote: 7.3.3
+RoxygenNote: 8.0.0
 Encoding: UTF-8
 Language: en-GB
 Config/testthat/edition: 3

--- a/R/lengthDS.R
+++ b/R/lengthDS.R
@@ -12,7 +12,7 @@
 #'
 lengthDS <- function(x){
   x.val <- .loadServersideObject(x)
-  .checkClass(obj = x.val, obj_name = x, permitted_classes = c("character", "factor", "integer", "logical", "numeric", "list", "data.frame"))
+  .checkClass(obj = x.val, obj_name = x, permitted_classes = c("character", "factor", "integer", "logical", "numeric", "list", "data.frame", "array", "matrix"))
   list(length = length(x.val), class = class(x.val))
 }
 #AGGREGATE FUNCTION

--- a/man/levelsDS.Rd
+++ b/man/levelsDS.Rd
@@ -10,9 +10,8 @@ levelsDS(x)
 \item{x}{a factor vector}
 }
 \value{
-a list with two elements: \code{Levels} (the factor levels present
-  in the vector) and \code{class} (the class of the input object, for
-  client-side consistency checking)
+a list with one element: \code{Levels} (the factor levels present
+  in the vector)
 }
 \description{
 This function is similar to R function \code{levels}.

--- a/tests/testthat/test-smk-lengthDS.R
+++ b/tests/testthat/test-smk-lengthDS.R
@@ -76,6 +76,26 @@ test_that("simple lengthDS, character data.frame", {
     expect_equal(res$class, "data.frame")
 })
 
+test_that("simple lengthDS, matrix", {
+    input <- matrix(1:6, nrow = 2, ncol = 3)
+
+    res <- lengthDS("input")
+
+    expect_equal(class(res), "list")
+    expect_equal(res$length, 6)
+    expect_equal(res$class, c("matrix", "array"))
+})
+
+test_that("simple lengthDS, array", {
+    input <- array(1:24, dim = c(2, 3, 4))
+
+    res <- lengthDS("input")
+
+    expect_equal(class(res), "list")
+    expect_equal(res$length, 24)
+    expect_equal(res$class, "array")
+})
+
 #
 # Done
 #

--- a/tests/testthat/test-smk-levelsDS.R
+++ b/tests/testthat/test-smk-levelsDS.R
@@ -52,6 +52,15 @@ test_that("levelsDS throws error when object is not a factor", {
     )
 })
 
+test_that("levelsDS blocks when levels density exceeds threshold", {
+    input <- factor(1:10, levels = 1:10)
+
+    expect_error(
+        levelsDS("input"),
+        regexp = "nfilter.levels.density"
+    )
+})
+
 #
 # Done
 #


### PR DESCRIPTION
## Background
I added class checks on the serverside for `lengthDS`, but was too restrictive which showed up in a failing clientside check.

## Solution
Add array and matrix as permitted classes.
